### PR TITLE
Keybase encrypt vault.json after automation.

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+#stdout_callback = yaml
+interpreter_python = /usr/local/bin/python3

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,10 @@
 # defaults file for keybase_unseal
 
 # https://en.wikipedia.org/wiki/Shamir%27s_Secret_Sharing
-shamir: true
+shamir: false
+
+# line-length hack
+ANSIBLE_VAULT_PASSWORD_FILE: "{{ lookup('env','ANSIBLE_VAULT_PASSWORD_FILE') }}"
 
 # create your own team on https://keybase.io
 keybase_team: 'dockpack.vault'

--- a/encrypt2each-member.yml
+++ b/encrypt2each-member.yml
@@ -1,0 +1,69 @@
+#!/usr/bin/env ansible-playbook -e python_interpreter=/usr/local/bin/python3
+---
+# This converts vault.json unencrypted shards to Keybase encrypted.
+# This enforces the Shamir Secret Sharing, after automating the unsealed Vault.
+
+- name: Encrypt each vault.json unseal key to a Keybase Team member
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+
+  vars_files:
+    - defaults/main.yml
+
+  tasks:
+
+    - name: Load encrypted Vault credentials
+      no_log: true
+      include_vars: "{{ vault_credentials }}"
+      register: json
+
+    - name: Create arrays
+      set_fact:
+        pgp_unseal_keys_b64: []
+        pgp_unseal_keys_hex: []
+
+    - name: Encrypt unseal keys and encode base64
+      shell: |
+        set -o pipefail; \
+        keybase pgp encrypt -m {{ item.0 }} -b {{ item.1 }} | base64
+      with_together:
+        - "{{ json.ansible_facts.unseal_keys_hex }}"
+        - "{{ kbt }}"
+      register: b64
+      no_log: true
+      changed_when: false
+
+    - name: Encrypt unseal keys and encode hex
+      shell: |
+        set -o pipefail; \
+        keybase pgp encrypt -m {{ item.0 }} -b {{ item.1 }} | xxd -p
+      with_together:
+        - "{{ json.ansible_facts.unseal_keys_hex }}"
+        - "{{ kbt }}"
+      register: hex
+      no_log: true
+      changed_when: false
+
+    - name: Add to arrays
+      set_fact:
+        pgp_unseal_keys_b64: "{{ pgp_unseal_keys_b64 + [ item.0.stdout ] }}"
+        pgp_unseal_keys_hex: "{{ pgp_unseal_keys_hex + [ item.1.stdout ] }}"
+      with_together:
+        - "{{ b64.results }}"
+        - "{{ hex.results }}"
+      no_log: true
+
+    - name: Write vault.json file in KBFS
+      copy:
+        content: "{{ lookup('template', 'templates/vault.j2') | to_nice_json }}"
+        dest: "{{ vault_credentials }}"
+
+    - name: Encrypt vault.json with ansible-vault
+      no_log: true
+      environment:
+        ANSIBLE_VAULT_PASSWORD_FILE: "{{ ANSIBLE_VAULT_PASSWORD_FILE }}"
+      command: "ansible-vault encrypt {{ vault_credentials }}"
+      changed_when: true
+...

--- a/tasks/seal.yml
+++ b/tasks/seal.yml
@@ -1,8 +1,7 @@
 ---
 # tasks_include for keybase_unseal by @bbaassssiiee
 
-- name: 'seal Hashicorp Vault with tags=seal -e seal=true'
-#  delegate_to: "{{ groups.vault_instances[0] }}"
+- name: 'seal Hashicorp Vault with --tags=seal -e seal=true'
   no_log: true
   when: seal is defined
   environment:

--- a/templates/vault.j2
+++ b/templates/vault.j2
@@ -1,0 +1,15 @@
+{
+    "recovery_keys_b64": [],
+    "recovery_keys_hex": [],
+    "recovery_keys_shares": "{{ json.ansible_facts.recovery_keys_shares }}",
+    "recovery_keys_threshold": "{{ json.ansible_facts.recovery_keys_threshold }}",
+    "root_token": "{{ json.ansible_facts.root_token }}",
+    "unseal_keys_b64":
+      {{ pgp_unseal_keys_b64 }}
+    ,
+    "unseal_keys_hex":
+      {{ pgp_unseal_keys_hex }}
+    ,
+    "unseal_shares": {{ json.ansible_facts.unseal_shares }},
+    "unseal_threshold": {{ json.ansible_facts.unseal_threshold }}
+}


### PR DESCRIPTION
- set `shamir: false`
- run the provisioner of vault on top of consul
- run `encrypt2each-member.yml`
- set `shamir: true`

After a restart you need `key_threshold` number of members of the `keybase_team` to unseal Hashicorp Vault.